### PR TITLE
Add linters for markdown, yaml, json and bash

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,21 @@
+---
+# markdownlint configuration
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+
+default: true
+
+# Allow duplicate headings (common in Hugo blog posts)
+MD024: false
+
+# Disable line length limit (blog posts have long lines)
+MD013: false
+
+# Allow inline HTML (Hugo shortcodes and custom HTML are used)
+MD033: false
+
+# Allow bare URLs (used in references and links)
+MD034: false
+
+# First line in file should be a top-level heading
+# Disabled because Hugo front matter is the first content
+MD041: false

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,13 @@
+---
+# Prettier configuration
+# https://prettier.io/docs/en/options.html
+
+printWidth: 120
+tabWidth: 2
+useTabs: false
+semi: false
+singleQuote: true
+trailingComma: "all"
+bracketSpacing: true
+proseWrap: "preserve"
+endOfLine: "lf"

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,8 @@
+# shellcheck configuration
+# https://www.shellcheck.net/wiki/Directive
+
+# Use bash as the default shell dialect
+shell=bash
+
+# Disable warnings for following sourced files (SC1091)
+disable=SC1091

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,16 @@
+---
+# yamllint configuration
+# https://yamllint.readthedocs.io/en/stable/configuration.html
+
+extends: default
+
+rules:
+  # Allow longer lines (GitHub Actions workflows can have long lines)
+  line-length:
+    max: 120
+    level: warning
+
+  # Allow both true/false and yes/no boolean values
+  truthy:
+    allowed-values: ['true', 'false', 'yes', 'no', 'on', 'off']
+    check-keys: false


### PR DESCRIPTION
Add linter configurations for markdownlint, yamllint, prettier, and shellcheck.

Note: please also add `.github/workflows/lint.yml` manually (see issue #12 comment for content).

Closes #12

Generated with [Claude Code](https://claude.ai/code)