### PR TITLE
Parallelize lint jobs and disable MD031

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,17 @@ on:
   pull_request:
 
 jobs:
-  lint:
+  changed-files:
     runs-on: ubuntu-latest
+    outputs:
+      markdown_any_changed: ${{ steps.changed-files.outputs.markdown_any_changed }}
+      markdown_all_changed_files: ${{ steps.changed-files.outputs.markdown_all_changed_files }}
+      yaml_any_changed: ${{ steps.changed-files.outputs.yaml_any_changed }}
+      yaml_all_changed_files: ${{ steps.changed-files.outputs.yaml_all_changed_files }}
+      json_any_changed: ${{ steps.changed-files.outputs.json_any_changed }}
+      json_all_changed_files: ${{ steps.changed-files.outputs.json_all_changed_files }}
+      bash_any_changed: ${{ steps.changed-files.outputs.bash_any_changed }}
+      bash_all_changed_files: ${{ steps.changed-files.outputs.bash_all_changed_files }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -31,26 +40,53 @@ jobs:
             bash:
               - '**/*.sh'
 
+  lint-markdown:
+    runs-on: ubuntu-latest
+    needs: changed-files
+    if: needs.changed-files.outputs.markdown_any_changed == 'true'
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+
       - name: Lint Markdown
-        if: steps.changed-files.outputs.markdown_any_changed == 'true'
         run: |
           npm install -g markdownlint-cli
-          markdownlint ${{ steps.changed-files.outputs.markdown_all_changed_files }}
+          markdownlint ${{ needs.changed-files.outputs.markdown_all_changed_files }}
+
+  lint-yaml:
+    runs-on: ubuntu-latest
+    needs: changed-files
+    if: needs.changed-files.outputs.yaml_any_changed == 'true'
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
 
       - name: Lint YAML
-        if: steps.changed-files.outputs.yaml_any_changed == 'true'
         run: |
           pip install yamllint
-          yamllint ${{ steps.changed-files.outputs.yaml_all_changed_files }}
+          yamllint ${{ needs.changed-files.outputs.yaml_all_changed_files }}
+
+  lint-json:
+    runs-on: ubuntu-latest
+    needs: changed-files
+    if: needs.changed-files.outputs.json_any_changed == 'true'
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
 
       - name: Lint JSON
-        if: steps.changed-files.outputs.json_any_changed == 'true'
         run: |
-          for f in ${{ steps.changed-files.outputs.json_all_changed_files }}; do
+          for f in ${{ needs.changed-files.outputs.json_all_changed_files }}; do
             python3 -m json.tool "$f" > /dev/null && echo "OK: $f" || echo "FAIL: $f"
           done
 
-      - name: Lint Bash
-        if: steps.changed-files.outputs.bash_any_changed == 'true'
-        run: shellcheck ${{ steps.changed-files.outputs.bash_all_changed_files }}
+  lint-bash:
+    runs-on: ubuntu-latest
+    needs: changed-files
+    if: needs.changed-files.outputs.bash_any_changed == 'true'
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
 
+      - name: Lint Bash
+        run: shellcheck ${{ needs.changed-files.outputs.bash_all_changed_files }}

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -19,3 +19,6 @@ MD034: false
 # First line in file should be a top-level heading
 # Disabled because Hugo front matter is the first content
 MD041: false
+
+# Allow fenced code blocks without surrounding blank lines
+MD031: false


### PR DESCRIPTION
## Summary

- Split the single `lint` job into parallel jobs: `lint-markdown`, `lint-yaml`, `lint-json`, `lint-bash`
- Added a `changed-files` job that detects changed files and exposes them as outputs for dependent jobs
- Disabled `MD031` (blanks-around-fences) in `.markdownlint.yml`

## Test plan

- [x] Verify all four lint jobs run in parallel in the Actions tab
- [x] Verify each job is skipped when no relevant files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)