### PR TITLE
Add LinuxDays 2025 Home Assistant blog post

### DIFF
--- a/content/post/linuxdays-2025-home-assistant.cs.md
+++ b/content/post/linuxdays-2025-home-assistant.cs.md
@@ -1,0 +1,17 @@
+---
+title: LinuxDays 2025 - Home Assistant
+date: 2025-10-05
+tags:
+  - přednášky
+  - linux
+  - home assistant
+authors:
+  - Pavel Dostal
+  - Ondrej Pithart
+---
+
+Na letošních [LinuxDays 2025](https://www.linuxdays.cz/2025/) jsme s Ondrou Pithartem měli přednášku o tom, jak začít s domácí automatizací v [Home Assistantovi](https://www.home-assistant.io/).
+
+<!--more-->
+
+{{< youtube rrvHafo-GC4 >}}

--- a/content/post/linuxdays-2025-home-assistant.en.md
+++ b/content/post/linuxdays-2025-home-assistant.en.md
@@ -1,0 +1,17 @@
+---
+title: LinuxDays 2025 - Home Assistant
+date: 2025-10-05
+tags:
+  - talks
+  - linux
+  - home assistant
+authors:
+  - Pavel Dostal
+  - Ondrej Pithart
+---
+
+At [LinuxDays 2025](https://www.linuxdays.cz/2025/), Ondrej Pithart and I gave a talk about getting started with home automation using [Home Assistant](https://www.home-assistant.io/).
+
+<!--more-->
+
+{{< youtube rrvHafo-GC4 >}}


### PR DESCRIPTION
## Summary

- Adds bilingual (CS/EN) blog post about the LinuxDays 2025 talk on Home Assistant
- Co-presented with Ondrej Pithart
- Embeds the YouTube recording (`rrvHafo-GC4`)

## Test plan

- [ ] Verify Hugo build passes
- [ ] Check post renders correctly in both languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)